### PR TITLE
Refactor to idiomatic Spring + Kotlin code

### DIFF
--- a/domain/src/main/kotlin/de/rpr/mycity/domain/DoubleAttributeConverter.kt
+++ b/domain/src/main/kotlin/de/rpr/mycity/domain/DoubleAttributeConverter.kt
@@ -5,15 +5,9 @@ import javax.persistence.AttributeConverter
 
 class DoubleAttributeConverter : AttributeConverter<Double, BigDecimal?> {
 
-    override fun convertToDatabaseColumn(attribute: Double?): BigDecimal? {
-        return if (attribute != null) {
-            BigDecimal(attribute)
-        } else {
-            null
-        }
-    }
+    override fun convertToDatabaseColumn(attribute: Double?) =
+            if (attribute != null) { BigDecimal(attribute) } else { null }
 
-    override fun convertToEntityAttribute(dbData: BigDecimal?): Double? {
-        return dbData?.toDouble()
-    }
+    override fun convertToEntityAttribute(dbData: BigDecimal?) =
+            dbData?.toDouble()
 }

--- a/domain/src/main/kotlin/de/rpr/mycity/domain/city/entity/CityEntity.kt
+++ b/domain/src/main/kotlin/de/rpr/mycity/domain/city/entity/CityEntity.kt
@@ -21,13 +21,6 @@ internal data class CityEntity(
         val updatedAt: LocalDateTime = LocalDateTime.now(),
         val createdAt: LocalDateTime = LocalDateTime.now()) {
 
-    // Default constructor for JPA
-    @Suppress("unused")
-    private constructor() : this(
-            name = "",
-            location = Coordinate.origin(),
-            updatedAt = LocalDateTime.MIN)
-
     fun toDto(): CityDto = CityDto(
             id = this.id!!,
             name = this.name,

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
-    <kotlin.version>1.1.2-2</kotlin.version>
+    <kotlin.version>1.1.2-5</kotlin.version>
     <mockito.version>2.8.9</mockito.version>
     <assertj.version>3.8.0</assertj.version>
   </properties>
@@ -105,6 +105,7 @@
         <configuration>
           <compilerPlugins>
             <plugin>spring</plugin>
+            <plugin>jpa</plugin>
           </compilerPlugins>
           <jvmTarget>1.8</jvmTarget>
         </configuration>
@@ -128,6 +129,11 @@
           <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-maven-allopen</artifactId>
+            <version>${kotlin.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-noarg</artifactId>
             <version>${kotlin.version}</version>
           </dependency>
         </dependencies>

--- a/web/src/main/kotlin/de/rpr/mycity/Application.kt
+++ b/web/src/main/kotlin/de/rpr/mycity/Application.kt
@@ -1,8 +1,5 @@
 package de.rpr.mycity
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.InjectionPoint
@@ -17,13 +14,6 @@ class Application {
     @Bean
     @Scope("prototype")
     fun logger(injectionPoint: InjectionPoint): Logger = LoggerFactory.getLogger(injectionPoint.methodParameter.containingClass)
-
-    @Bean
-    fun objectMapper(): ObjectMapper {
-        val mapper = ObjectMapper().registerModule(KotlinModule())
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        return mapper
-    }
 
 }
 


### PR DESCRIPTION
Great blog post and sample project!

My proposed improvements
 - Usage of Kotlin JPA compiler plugin to generate default constructors
 - Jackson builder already register Kotlin module with sensible defaults
 - One liner syntax + type inference when possible

Also be aware than extensions are sometimes more idiomatic than `companion object` in Kotlin but it depends of your use case. See for example https://github.com/mixitconf/mixit/blob/master/src/main/kotlin/mixit/web/handler/BlogHandler.kt#L58.

Are you ok with these proposed changes?
If yes any chance you could also update the blog post?